### PR TITLE
Specify minimum wisper version

### DIFF
--- a/wisper-visualize.gemspec
+++ b/wisper-visualize.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'wisper'
+  spec.add_dependency 'wisper', ">= 1.5.0"
   spec.add_dependency 'ruby-graphviz'
 end


### PR DESCRIPTION
I am trying to use this gem with wisper v1.4.0, but it had no method named `configure` back then.
```
Failure/Error: report = Wisper::Visualize.report
     
     NoMethodError:
       undefined method `configure' for Wisper:Module

     # /home/me/.rvm/gems/ruby-2.2.7/gems/wisper-visualize-0.0.1/lib/wisper/visualize/report.rb:6:in `initialize'
     # /home/me/.rvm/gems/ruby-2.2.7/gems/wisper-visualize-0.0.1/lib/wisper/visualize.rb:11:in `new'
     # /home/me/.rvm/gems/ruby-2.2.7/gems/wisper-visualize-0.0.1/lib/wisper/visualize.rb:11:in `report'
     # ./spec/spec_helper.rb:83:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:78:in `block (3 levels) in <top (required)>'
```